### PR TITLE
Fix: Return "Not Found" for invalid Pokémon IDs and Update the Pokemon Range to 1025 according to National Pokedex

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def pokemon():
         
         # Check if the ID is numeric and within the range
         if id.isnumeric():
-            id_num = int(id)
+            id_num = int(id)  # Convert to integer for comparison
             if id_num < 1 or id_num > 1025:
                 return "Not Found"  # Return "Not Found" for out-of-range numbers
         else:

--- a/main.py
+++ b/main.py
@@ -12,13 +12,17 @@ AUTH_HEADER = {"Authorization": "622BEB8354BCDC1C94E1B5B414C66"}
 @app.route("/")
 def pokemon():
     try:
-        if request.args.get("search") == None:
-            id = "1"
+         # Set default ID to 1
+        id = request.args.get("search", "1").lower()
+        
+        # Check if the ID is numeric and within the range
+        if id.isnumeric():
+            id_num = int(id)
+            if id_num < 1 or id_num > 1025:
+                return "Not Found"  # Return "Not Found" for out-of-range numbers
         else:
-            id = request.args.get("search").lower()
-            if id.isnumeric():
-                if id < "1" or id > "905":
-                    id = "1"
+            return "Write the Vaild ID"  # Return "Write the Valid ID" for non-numeric input
+            
         response = requests.get(
             f"https://api.pokemon.project.projectrexa.dedyn.io/pokeapi/{id}",
             headers=AUTH_HEADER,

--- a/main.py
+++ b/main.py
@@ -12,16 +12,14 @@ AUTH_HEADER = {"Authorization": "622BEB8354BCDC1C94E1B5B414C66"}
 @app.route("/")
 def pokemon():
     try:
-         # Set default ID to 1
         id = request.args.get("search", "1").lower()
         
-        # Check if the ID is numeric and within the range
         if id.isnumeric():
-            id_num = int(id)  # Convert to integer for comparison
+            id_num = int(id)  
             if id_num < 1 or id_num > 1025:
-                return "Not Found"  # Return "Not Found" for out-of-range numbers
+                return "Not Found"  
         else:
-            return "Write the Vaild ID"  # Return "Write the Valid ID" for non-numeric input
+            return "Not Found" 
             
         response = requests.get(
             f"https://api.pokemon.project.projectrexa.dedyn.io/pokeapi/{id}",


### PR DESCRIPTION
 This pull request improves the error handling for Pokémon ID validation in the / route.
 **Previously,** IDs above **905** defaulted to Pokémon #1.

 ### Changes :
 Now, any invalid ID (non-numeric or out of the range **1-1025**) will return "Not Found".
 Modified the route to return "Not Found" for any invalid ID or "Enter a Valid ID" for String Inputs.